### PR TITLE
Temporarily disabled the storage "dir" setting.

### DIFF
--- a/starlark/stable/pipeline.star
+++ b/starlark/stable/pipeline.star
@@ -104,7 +104,6 @@ def storage_resource(name, location="s3://artifacts", secret="s3-config", pipeli
     resource(name, type="storage", params={
         "type": "gcs",
         "location": location,
-        "dir": "y"
     }, secrets={
         "BOTO_CONFIG": k8s.corev1.SecretKeySelector(key="boto", localObjectReference=k8s.corev1.LocalObjectReference(name=secret))
     }, pipeline=pipeline)


### PR DESCRIPTION
Right now the `dir` setting will trigger `rsync -d -r` to top-level `s3://artifacts` so temporarily disable it. Will re-enable it once workarounds are in place in Dispatch.