### PR TITLE
Enabled directory for storage resources but don't use root bucket as default location.

### DIFF
--- a/starlark/stable/pipeline.star
+++ b/starlark/stable/pipeline.star
@@ -103,7 +103,8 @@ def storage_resource(name, location="s3://artifacts", secret="s3-config", pipeli
 
     resource(name, type="storage", params={
         "type": "gcs",
-        "location": location,
+        "location": "{}/{}".format(location, name),
+        "dir": "y"
     }, secrets={
         "BOTO_CONFIG": k8s.corev1.SecretKeySelector(key="boto", localObjectReference=k8s.corev1.LocalObjectReference(name=secret))
     }, pipeline=pipeline)


### PR DESCRIPTION
This is a temporary change before workarounds are in place.