### PR TITLE
dind_task: specify command if not provided

### DIFF
--- a/docs/starlark/stable/docker.md
+++ b/docs/starlark/stable/docker.md
@@ -6,23 +6,29 @@ Provides methods for using Docker.
 To import, add the following to your Dispatchfile:
 
 ```
-load("github.com/mesosphere/dispatch-catalog/starlark/stable/docker@0.0.4", "dindTask")
+load("github.com/mesosphere/dispatch-catalog/starlark/stable/docker@0.0.5", "dind_task")
 ```
 
 
-### dindTask(*args, **kwargs)
+### dind_task(name, steps, volumes, **kwargs)
 
 
 Defines a new docker-in-docker task in a pipeline. The steps are run in the default `mesosphere/dispatch-dind` image unless an alternative image is specified.
 
 Example usage:
 
-```sh
-dindTask("test", inputs=["git"], steps=[k8s.corev1.Container(
+```python
+dind_task("test", inputs=["git"], steps=[k8s.corev1.Container(
     name="test",
-    command=["docker", "run", "-v", "/workspace/git:/workspace/git", "-w", "/workspace/git", "golang:1.13.0-buster", "go", "test", "./..."],
+    args=["docker", "run", "-v", "/workspace/git:/workspace/git", "-w", "/workspace/git", "golang:1.13.0-buster", "go", "test", "./..."],
 )])
 ```
+
+
+### dindTask(*args, **kwargs)
+
+
+DEPRECATED: Use dind_task instead.
 
 
 

--- a/starlark/stable/docker.star
+++ b/starlark/stable/docker.star
@@ -22,9 +22,9 @@ def dind_task(name, steps=[], volumes=[], **kwargs):
     Example usage:
 
     ```python
-    dindTask("test", inputs=["git"], steps=[k8s.corev1.Container(
+    dind_task("test", inputs=["git"], steps=[k8s.corev1.Container(
         name="test",
-        command=["docker", "run", "-v", "/workspace/git:/workspace/git", "-w", "/workspace/git", "golang:1.13.0-buster", "go", "test", "./..."],
+        args=["docker", "run", "-v", "/workspace/git:/workspace/git", "-w", "/workspace/git", "golang:1.13.0-buster", "go", "test", "./..."],
     )])
     ```
     """
@@ -38,6 +38,8 @@ def dind_task(name, steps=[], volumes=[], **kwargs):
     for index, step in enumerate(steps):
         if step.image == "":
             step.image = "mesosphere/dispatch-dind:1.1.0"
+        if not step.command:
+            step.command = ["/entrypoint.sh"]
         step.volumeMounts.extend([
             k8s.corev1.VolumeMount(name="docker", mountPath="/var/lib/docker"),
             k8s.corev1.VolumeMount(name="modules", mountPath="/lib/modules", readOnly=True),


### PR DESCRIPTION
For airgapped customers, the command needs to be set explicitly:
https://docs.d2iq.com/ksphere/dispatch/1.1/operations/airgap-support/

If the user does not set it explicitly, we set it for them.

TODO:
- [x] update the dindTask docs