### PR TITLE
feat: ko should allow building non-root module

### DIFF
--- a/docs/starlark/experimental/go.md
+++ b/docs/starlark/experimental/go.md
@@ -22,7 +22,7 @@ Run Go tests and generate a coverage report.
 Build Go binaries.
 
 
-### ko(task_name, git_name, image_repo, path, tag, ldflags, inputs, outputs, steps, **kwargs)
+### ko(task_name, git_name, image_repo, path, tag, ldflags, working_dir, inputs, outputs, steps, env, **kwargs)
 
 
 Build a Docker container for a Go binary using ko.

--- a/docs/starlark/stable/go.md
+++ b/docs/starlark/stable/go.md
@@ -21,8 +21,7 @@ Run Go tests and generate a coverage report.
 Build a Go binary.
 
 
-### ko(task_name, git_name, image_repo, path, tag, ldflags, inputs, outputs, steps, **kwargs)
-
+### ko(task_name, git_name, image_repo, path, tag, ldflags, working_dir, inputs, outputs, steps, env, **kwargs)
 
 Build a Docker container for a Go binary using ko.
 

--- a/starlark/experimental/go.star
+++ b/starlark/experimental/go.star
@@ -1,6 +1,7 @@
 # vi:syntax=python
 
 load("/starlark/stable/pipeline", "git_checkout_dir", "image_resource", "storage_resource")
+load("/starlark/stable/path", "join")
 load("/starlark/experimental/buildkit", "buildkit_container")
 
 __doc__ = """
@@ -91,7 +92,7 @@ go build -o $(resources.outputs.{storage}.path)/{os}_{arch}/ {build_args} {paths
 
     return storage_name
 
-def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldflags=None, working_dir=None, inputs=[], outputs=[], steps=[], env=[], **kwargs):
+def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldflags=None, working_dir="", inputs=[], outputs=[], steps=[], env=[], **kwargs):
     """
     Build a Docker container for a Go binary using ko.
 
@@ -115,10 +116,6 @@ def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldfla
         k8s.corev1.EnvVar(name="KO_DOCKER_REPO", value="-") # This value is arbitrary to pass ko's validation.
     ]
 
-    build_working_dir = git_checkout_dir(git_name)
-    if working_dir:
-        build_working_dir = build_working_dir + working_dir
-
     if ldflags:
         env.append(k8s.corev1.EnvVar(name="GOFLAGS", value="-ldflags={}".format(ldflags)))
 
@@ -133,7 +130,7 @@ def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldfla
                 path
             ],
             env=env,
-            workingDir=build_working_dir,
+            workingDir=join(git_checkout_dir(git_name), working_dir),
             output_paths=["$(resources.outputs.{}.path)".format(image_name)]
         ),
         k8s.corev1.Container(

--- a/starlark/experimental/go.star
+++ b/starlark/experimental/go.star
@@ -91,9 +91,15 @@ go build -o $(resources.outputs.{storage}.path)/{os}_{arch}/ {build_args} {paths
 
     return storage_name
 
-def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldflags=None, inputs=[], outputs=[], steps=[], **kwargs):
+def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldflags=None, working_dir=None, inputs=[], outputs=[], steps=[], env=[], **kwargs):
     """
     Build a Docker container for a Go binary using ko.
+
+    Args:
+        `working_dir` optionally can provide a path to a subdirectory within
+        the git repository. This can be used if repository has multiple
+        go modules and there is a need to build the module that is outside of
+        root directory.
     """
 
     image_name = image_resource(
@@ -104,10 +110,14 @@ def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldfla
     inputs = inputs + [git_name]
     outputs = outputs + [image_name]
 
-    env = [
+    env = env + [
         k8s.corev1.EnvVar(name="GO111MODULE", value="on"),
         k8s.corev1.EnvVar(name="KO_DOCKER_REPO", value="-") # This value is arbitrary to pass ko's validation.
     ]
+
+    build_working_dir = git_checkout_dir(git_name)
+    if working_dir:
+        build_working_dir = build_working_dir + working_dir
 
     if ldflags:
         env.append(k8s.corev1.EnvVar(name="GOFLAGS", value="-ldflags={}".format(ldflags)))
@@ -123,7 +133,7 @@ def ko(task_name, git_name, image_repo, path, tag="$(context.build.name)", ldfla
                 path
             ],
             env=env,
-            workingDir=git_checkout_dir(git_name),
+            workingDir=build_working_dir,
             output_paths=["$(resources.outputs.{}.path)".format(image_name)]
         ),
         k8s.corev1.Container(

--- a/starlark/stable/path.star
+++ b/starlark/stable/path.star
@@ -19,3 +19,15 @@ def basename(path):
     """
 
     return path.rpartition("/")[2]
+
+def join(path, *paths):
+    """Join two or more path components, inserting '/' as needed.
+    If any component is an absolute path, all previous path components
+    will be discarded."""
+
+    for p in paths:
+        if p.startswith("/"):
+            path = p
+        elif p != "":
+            path += ("" if path == "" or path.endswith("/") else "/") + p
+    return path


### PR DESCRIPTION
Adds new features to `ko` function:

- Allow specifying environment variables. That is useful when `GITHUB_TOKEN` is need in order to build `go` projects that are referencing private modules
- Adds `working_dir` argument that allows building projects that consist of multiple go modules within a single repository.